### PR TITLE
Addition of Content-Length to the header of the request

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
-	"encoding/json"
 )
 
 func getFolderMetadataHandler(w http.ResponseWriter, r *http.Request) {
@@ -58,14 +58,14 @@ func getFileContentHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 type FileMetadata struct {
-	Name         string        `json:"name"`
-	Size         int64         `json:"size"`
-	IsDirectory  bool          `json:"isDirectory"`
-	LastModified time.Time     `json:"lastModified"`
-	Children     []FileMetadata `json:"children,omitempty"` 
+	Name         string         `json:"name"`
+	Size         int64          `json:"size"`
+	IsDirectory  bool           `json:"isDirectory"`
+	LastModified time.Time      `json:"lastModified"`
+	Children     []FileMetadata `json:"children,omitempty"`
 }
 
-func walkFolders(path string)(FileMetadata, error){
+func walkFolders(path string) (FileMetadata, error) {
 	node := FileMetadata{}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -96,19 +96,19 @@ func getFileContent(fileName string) ([]byte, error) {
 }
 
 func main() {
-		if len(os.Args) < 3 {
-			fmt.Println("Usage: ./filebrowser <folderPath> <PORT>")
-			os.Exit(1)
-		}
-	
-		port := os.Args[2]
-	
-		http.HandleFunc("/folder-metadata", getFolderMetadataHandler)
-		http.HandleFunc("/file-content", getFileContentHandler)
-		log.Printf("Server is running on http://localhost:%s", port)
-		log.Fatal(http.ListenAndServe(":"+port, nil))
+	if len(os.Args) < 3 {
+		fmt.Println("Usage: ./filebrowser <folderPath> <PORT>")
+		os.Exit(1)
 	}
-	
+
+	port := os.Args[2]
+
+	http.HandleFunc("/folder-metadata", getFolderMetadataHandler)
+	http.HandleFunc("/file-content", getFileContentHandler)
+	log.Printf("Server is running on http://localhost:%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}
+
 func getFolderPathFromArgs() string {
 	if len(os.Args) >= 2 {
 		return os.Args[1]

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 )
 
@@ -47,6 +48,14 @@ func getFileContentHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to read file content: %s", err), http.StatusInternalServerError)
 		return
+	}
+
+	// Get file size
+	fileSize, err := getFileSize(filepath.Join(folderPath, fileName))
+
+	// Set the Content-Length header only if we could read the fileSize successfully
+	if err == nil {
+		w.Header().Set("Content-Length", strconv.FormatInt(fileSize, 10))
 	}
 
 	// Respond with file content as octet/stream
@@ -93,6 +102,14 @@ func walkFolders(path string) (FileMetadata, error) {
 
 func getFileContent(fileName string) ([]byte, error) {
 	return os.ReadFile(fileName)
+}
+
+func getFileSize(fileName string) (int64, error) {
+	info, err := os.Stat(fileName)
+	if err != nil {
+		return 0, err
+	}
+	return info.Size(), nil
 }
 
 func main() {


### PR DESCRIPTION
Adding Content-Length to the header of the _/file-content_ requests, allows us to see the length of the file and the download progress.

In case of a failure to read the size of the file, we simply ignore adding the header altogether.